### PR TITLE
Fix image selection on Chrome

### DIFF
--- a/vendor/assets/javascripts/tinymce/tiny_mce_jquery_src.js
+++ b/vendor/assets/javascripts/tinymce/tiny_mce_jquery_src.js
@@ -1570,14 +1570,7 @@ tinymce.util.Quirks = function(editor) {
 		editor.onClick.add(function(editor, e) {
 			e = e.target;
 
-			// Workaround for bug, http://bugs.webkit.org/show_bug.cgi?id=12250
-			// WebKit can't even do simple things like selecting an image
-			// Needs tobe the setBaseAndExtend or it will fail to select floated images
-			if (/^(IMG|HR)$/.test(e.nodeName)) {
-				selection.getSel().setBaseAndExtent(e, 0, e, 1);
-			}
-
-			if (e.nodeName == 'A' && dom.hasClass(e, 'mceItemAnchor')) {
+			if ((/^(IMG|HR)$/.test(e.nodeName)) || (e.nodeName == 'A' && dom.hasClass(e, 'mceItemAnchor'))) {
 				selection.select(e);
 			}
 


### PR DESCRIPTION
This change removes the WebKit workaround, fixing image selection for TinyMCE 3.  Confirmed locally on nbuild that it works